### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,7 @@
 name: Docker Image
+permissions:
+  contents: read
+  packages: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JWeinelt/Caesar/security/code-scanning/7](https://github.com/JWeinelt/Caesar/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to set this at the top level of the workflow (applies to all jobs), unless a job requires different permissions. For a Docker build-and-push workflow that pushes to the GitHub Container Registry, the minimal required permission is usually `contents: read` (to check out code) and `packages: write` (to push to the registry). Therefore, add the following block after the `name` field and before the `on` field:

```yaml
permissions:
  contents: read
  packages: write
```

No additional imports or definitions are needed. Only the workflow YAML file needs to be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
